### PR TITLE
Seo frontmatter

### DIFF
--- a/src/components/common/Metadata.astro
+++ b/src/components/common/Metadata.astro
@@ -7,6 +7,7 @@ import type { Props as AstroSeoProps } from '@astrolib/seo';
 import { SITE, METADATA, I18N } from '~/utils/config';
 import type { MetaData } from '~/types';
 import { getCanonical } from '~/utils/permalinks';
+import { parseMetaRobots } from '~/utils/utils';
 
 import { adaptOpenGraphImages } from '~/utils/images';
 
@@ -62,18 +63,9 @@ const seoProps: AstroSeoProps = merge(
     description: description,
     openGraph: { url: canonical, ...openGraph },
     twitter: twitter,
-  }
+  },
+  robotsString ? parseMetaRobots(robotsString) : {}
 );
-
-if (robotsString !== undefined) {
-  delete seoProps.noindex;
-  delete seoProps.nofollow;
-
-  if (robots.follow || robots.index) {
-    console.warn(`robots field is overridden by robotsString: ${canonical}`);
-  }
-}
 ---
 
 <AstroSeo {...{ ...seoProps, openGraph: await adaptOpenGraphImages(seoProps?.openGraph, Astro.site) }} />
-{robotsString && <meta name="robots" content={robotsString} />}

--- a/src/components/common/Metadata.astro
+++ b/src/components/common/Metadata.astro
@@ -19,6 +19,7 @@ const {
   ignoreTitleTemplate = false,
   canonical = String(getCanonical(String(Astro.url.pathname))),
   robots = {},
+  robotsString,
   description,
   openGraph = {},
   twitter = {},
@@ -63,6 +64,16 @@ const seoProps: AstroSeoProps = merge(
     twitter: twitter,
   }
 );
+
+if (robotsString !== undefined) {
+  delete seoProps.noindex;
+  delete seoProps.nofollow;
+
+  if (robots.follow || robots.index) {
+    console.warn(`robots field is overridden by robotsString: ${canonical}`);
+  }
+}
 ---
 
 <AstroSeo {...{ ...seoProps, openGraph: await adaptOpenGraphImages(seoProps?.openGraph, Astro.site) }} />
+{robotsString && <meta name="robots" content={robotsString} />}

--- a/src/layouts/MarkdownLayout.astro
+++ b/src/layouts/MarkdownLayout.astro
@@ -5,14 +5,16 @@ import type { MetaData } from '~/types';
 
 export interface Props {
   frontmatter: {
-    title?: string
-  }
+    title?: string;
+    seoTitle?: string;
+  };
 }
 
 const { frontmatter } = Astro.props;
 
 const metadata: MetaData = {
-  title: frontmatter?.title,
+  title: frontmatter?.seoTitle || frontmatter?.title,
+  ignoreTitleTemplate: !!frontmatter?.seoTitle,
 };
 ---
 

--- a/src/layouts/MarkdownLayout.astro
+++ b/src/layouts/MarkdownLayout.astro
@@ -7,6 +7,7 @@ export interface Props {
   frontmatter: {
     title?: string;
     seoTitle?: string;
+    metaRobots?: string;
   };
 }
 
@@ -15,6 +16,7 @@ const { frontmatter } = Astro.props;
 const metadata: MetaData = {
   title: frontmatter?.seoTitle || frontmatter?.title,
   ignoreTitleTemplate: !!frontmatter?.seoTitle,
+  robotsString: frontmatter?.metaRobots,
 };
 ---
 

--- a/src/pages/[...blog]/index.astro
+++ b/src/pages/[...blog]/index.astro
@@ -30,10 +30,14 @@ const metadata = merge(
     title: post.seoTitle || post.title,
     ignoreTitleTemplate: !!post?.seoTitle,
     description: post.excerpt,
-    robots: {
-      index: blogPostRobots?.index,
-      follow: blogPostRobots?.follow,
-    },
+    robots:
+      post?.metaRobots === undefined
+        ? {
+            index: blogPostRobots?.index,
+            follow: blogPostRobots?.follow,
+          }
+        : {},
+    robotsString: post?.metaRobots,
     openGraph: {
       type: 'article',
       ...(image

--- a/src/pages/[...blog]/index.astro
+++ b/src/pages/[...blog]/index.astro
@@ -27,7 +27,8 @@ const image = (await findImage(post.image)) as ImageMetadata | string | undefine
 
 const metadata = merge(
   {
-    title: post.title,
+    title: post.seoTitle || post.title,
+    ignoreTitleTemplate: !!post?.seoTitle,
     description: post.excerpt,
     robots: {
       index: blogPostRobots?.index,
@@ -35,7 +36,9 @@ const metadata = merge(
     },
     openGraph: {
       type: 'article',
-      ...(image ? { images: [{ url: image, width: (image as ImageMetadata)?.width, height: (image as ImageMetadata)?.height }] } : {}),
+      ...(image
+        ? { images: [{ url: image, width: (image as ImageMetadata)?.width, height: (image as ImageMetadata)?.height }] }
+        : {}),
     },
   },
   { ...(post?.metadata ? { ...post.metadata, canonical: post.metadata?.canonical || url } : {}) }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,6 +18,8 @@ export interface Post {
 
   /**  */
   title: string;
+  /** if unset, defaults to title */
+  seoTitle?: string;
   /** Optional summary of post content. */
   excerpt?: string;
   /**  */

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -53,6 +53,8 @@ export interface MetaData {
   canonical?: string;
 
   robots?: MetaDataRobots;
+  /** Sets the content for `<meta name="robots">` to an arbitrary string. Overrides the `robots` property. */
+  robotsString?: string;
 
   description?: string;
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -35,6 +35,8 @@ export interface Post {
   /**  */
   metadata?: MetaData;
 
+  metaRobots?: string;
+
   /**  */
   draft?: boolean;
 

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -48,6 +48,7 @@ const getNormalizedPost = async (post: CollectionEntry<'post'>): Promise<Post> =
     publishDate: rawPublishDate = new Date(),
     updateDate: rawUpdateDate,
     title,
+    seoTitle,
     excerpt,
     image,
     tags: rawTags = [],
@@ -72,6 +73,7 @@ const getNormalizedPost = async (post: CollectionEntry<'post'>): Promise<Post> =
     updateDate: updateDate,
 
     title: title,
+    seoTitle: seoTitle,
     excerpt: excerpt,
     image: image,
 

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -56,6 +56,7 @@ const getNormalizedPost = async (post: CollectionEntry<'post'>): Promise<Post> =
     author,
     draft = false,
     metadata = {},
+    metaRobots,
   } = data;
 
   const slug = cleanSlug(rawSlug); // cleanSlug(rawSlug.split('/').pop());
@@ -84,6 +85,7 @@ const getNormalizedPost = async (post: CollectionEntry<'post'>): Promise<Post> =
     draft: draft,
 
     metadata,
+    metaRobots,
 
     Content: Content,
     // or 'content' in case you consume from API

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,4 @@
+import type { AstroSeoProps, ImagePrevSize } from '@astrolib/seo';
 import { I18N } from '~/utils/config';
 
 const formatter: Intl.DateTimeFormat =
@@ -52,3 +53,34 @@ export const toUiAmount = (amount: number) => {
 
   return value;
 };
+
+const isImagePrevSize = (str: string): str is ImagePrevSize => str === 'none' || str === 'standard' || str === 'large';
+
+export type MetaRobots = Pick<AstroSeoProps, 'noindex' | 'nofollow' | 'robotsProps'>;
+
+export function parseMetaRobots(robotsString: string): MetaRobots {
+  const fields = robotsString.split(/\s*,\s*/);
+
+  const none = fields.includes('none');
+  const maxSnippet = Number(fields.find((f) => f.startsWith('max-snippet'))?.split(':')?.[1]);
+  const maxImagePreview = fields.find((f) => f.startsWith('max-image-preview'))?.split(':')?.[1];
+  const maxVideoPreview = Number(fields.find((f) => f.startsWith('max-video-preview'))?.split(':')?.[1]);
+  const unavailableAfter = fields.find((f) => f.startsWith('unavailable_after'))?.split(':')?.[1];
+
+  const parsed: MetaRobots = {
+    noindex: fields.includes('noindex') || none, // default to index
+    nofollow: fields.includes('nofollow') || none, // default to follow
+    robotsProps: {
+      nosnippet: fields.includes('nosnippet'),
+      maxSnippet: !Number.isNaN(maxSnippet) ? maxSnippet : undefined,
+      maxImagePreview: maxImagePreview && isImagePrevSize(maxImagePreview) ? maxImagePreview : undefined,
+      maxVideoPreview: !Number.isNaN(maxVideoPreview) ? maxVideoPreview : undefined, // not implemented yet in astrolib/seo... but keeping this in case it is later
+      noarchive: fields.includes('noarchive'),
+      unavailableAfter,
+      noimageindex: fields.includes('noimageindex'),
+      notranslate: fields.includes('notranslate'),
+    },
+  };
+
+  return parsed;
+}


### PR DESCRIPTION
Updated with optional `metaRobots` and `seoTitle` fields on markdown pages and blog posts (if that's desired). [Here's a link to the Loom video](https://www.loom.com/share/1033f8061ae74d719f62ce49a7f89692?sid=14534202-977a-4133-aa31-ba2528f9a739) walking through everything. Sorry if it's overlong, first time using Loom like this.

Some notes:
- An alternative to setting `metaRobots` as a string is passing a frontmatter object to the `robotsProps` option in [@astrolib/seo](https://github.com/onwidget/astrolib/tree/main/packages/seo), if the available options for that are sufficient.
- I set `seoTitle` to override the title template, which means that a page with a template like `${title} – SERP` will just become whatever is passed to `seoTitle`. But not sure if that's the desired behavior.

/claim serpcompany/public#5